### PR TITLE
Fix header timestamp.

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,10 @@
 = Marketo
 
+== Test steps
+1. Uncomment customized httpi gem in Gemfile.
+2. Create file spec/config/marketo.yml with proper testing credentials.
+3. Change Timecop freeze statement in marketo_spec.rb to update VCR cassettes first time.
+
 == Setup
 
 Create a config/marketo.yml file:

--- a/lib/marketo/interface.rb
+++ b/lib/marketo/interface.rb
@@ -149,40 +149,23 @@ module Marketo
     end
   end
 
-  class AuthenticationHeader
+  class AuthenticationHeader < Struct.new(:access_key, :secret_key)
     DIGEST = OpenSSL::Digest::Digest.new('sha1')
 
-    def initialize(access_key, secret_key, time = DateTime.now)
-      @access_key = access_key
-      @secret_key = secret_key
-      @time = time
-    end
-
     def to_hash
+      request_timestamp = DateTime.now.to_s
       {
-        "mktowsUserId"     => get_mktows_user_id,
-        "requestSignature" => get_request_signature,
-        "requestTimestamp" => get_request_timestamp
+        "mktowsUserId"     => access_key,
+        "requestSignature" => calculate_signature(request_timestamp),
+        "requestTimestamp" => request_timestamp
       }
     end
 
-    def get_mktows_user_id
-      @access_key
-    end
-
-    def get_request_signature
-      calculate_signature
-    end
-
-    def get_request_timestamp
-      @time.to_s
-    end
-
     private
-    def calculate_signature
-      request_timestamp = get_request_timestamp
-      string_to_encrypt = request_timestamp + @access_key
-      OpenSSL::HMAC.hexdigest(DIGEST, @secret_key, string_to_encrypt)
+
+    def calculate_signature(request_timestamp_string)
+      string_to_encrypt = request_timestamp_string.to_s + access_key
+      OpenSSL::HMAC.hexdigest(DIGEST, secret_key, string_to_encrypt)
     end
   end
 end

--- a/marketo.gemspec
+++ b/marketo.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('savon', '~> 1.0')
+  s.add_dependency('savon', '~> 1.1.0')
   s.add_development_dependency('vcr')
   s.add_development_dependency('timecop')
   s.add_development_dependency('rspec')

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -1,0 +1,25 @@
+require_relative 'spec_helper'
+require "marketo"
+
+describe Marketo do
+  describe Marketo::Interface do
+    IDNUM = 1000074
+    EMAIL = "john@backupify.com"
+    COOKIE = "id:572-ZRG-001&token:_mch-localhost-1306412206125-92040"
+    USER = { :email => "john@backupify.com", :first_name => "john", :last_name => "kelly" }
+
+    describe 'to_hash' do
+      it 'should update timestamp on every call to avoid request expiration' do
+        client = Marketo::Client.new_marketo_client
+
+        first_timestamp = client.instance_variable_get(:@header).to_hash["requestTimestamp"]
+        Timecop.freeze(Time.now + 10)
+        second_timestamp = client.instance_variable_get(:@header).to_hash["requestTimestamp"]
+
+        first_timestamp.should_not == second_timestamp
+
+        Timecop.return
+      end
+    end
+  end
+end

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -1,13 +1,7 @@
 require_relative 'spec_helper'
-require "marketo"
 
 describe Marketo do
   describe Marketo::Interface do
-    IDNUM = 1000074
-    EMAIL = "john@backupify.com"
-    COOKIE = "id:572-ZRG-001&token:_mch-localhost-1306412206125-92040"
-    USER = { :email => "john@backupify.com", :first_name => "john", :last_name => "kelly" }
-
     describe 'to_hash' do
       it 'should update timestamp on every call to avoid request expiration' do
         client = Marketo::Client.new_marketo_client


### PR DESCRIPTION
Authentication header will update timestamp every time it was asked to compose hash for request.
