### PR TITLE
Change client timeouts

### DIFF
--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -19,7 +19,7 @@ module Marketo
       end
 
       @client.config.soap_version = 1
-      @client.http.auth.ssl.ssl_version = :SSLv3
+      @client.http.auth.ssl.ssl_version = :TLSv1
       @client.http.open_timeout = 240
       @client.http.read_timeout = 240
       @header = AuthenticationHeader.new(config.access_key, config.secret_key)

--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -20,6 +20,8 @@ module Marketo
 
       @client.config.soap_version = 1
       @client.http.auth.ssl.ssl_version = :SSLv3
+      @client.http.open_timeout = 240
+      @client.http.read_timeout = 240
       @header = AuthenticationHeader.new(config.access_key, config.secret_key)
 
       Interface.new(@client, @header)

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -11,7 +11,11 @@ describe Marketo do
     USER = { :email => "john@backupify.com", :first_name => "john", :last_name => "kelly" }
 
     before(:all) do
-      Timecop.freeze(Time.now)
+      # To test:
+      # Remove Timecop.freeze or setup Time.now.
+      # Record VCR cassettes with actual responses from Marketo.
+      # Setup Timecop with time of requests to eliminate 'Request expired' Error.
+      Timecop.freeze(Time.parse('17 Dec 2013 18:59:40 GMT'))
       @interface = Marketo::Client.new_marketo_client
     end
 

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -19,6 +19,16 @@ describe Marketo do
       Timecop.return
     end
 
+    describe 'Client timeouts' do
+      it 'should set open timeout to 240 seconds' do
+        @interface.client.http.open_timeout.should be_equal 240
+      end
+
+      it 'should set read timeout to 240 seconds' do
+        @interface.client.http.read_timeout.should be_equal 240
+      end
+    end
+
     describe 'Exception handling' do
       before do
         VCR.insert_cassette "fault", :record => :new_episodes

--- a/spec/interface_spec.rb
+++ b/spec/interface_spec.rb
@@ -1,18 +1,18 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require_relative 'spec_helper'
 require "marketo"
 require "yaml"
 require "erb"
 
 describe Marketo do
-  describe Marketo::Client do
+  describe Marketo::Interface do
     IDNUM = 1000074
     EMAIL = "john@backupify.com"
     COOKIE = "id:572-ZRG-001&token:_mch-localhost-1306412206125-92040"
     USER = { :email => "john@backupify.com", :first_name => "john", :last_name => "kelly" }
 
     before(:all) do
-      Timecop.freeze(Time.parse('17 Dec 2013 18:59:40 GMT'))
-      @client = Marketo::Client.new_marketo_client
+      Timecop.freeze(Time.now)
+      @interface = Marketo::Client.new_marketo_client
     end
 
     after(:all) do
@@ -25,19 +25,19 @@ describe Marketo do
       end
 
       it "should return error if no id is provided" do
-        lambda { @client.get_lead_by_id(nil) }.should raise_exception(Exception, "ID must be provided")
+        lambda { @interface.get_lead_by_id(nil) }.should raise_exception(Exception, "ID must be provided")
       end
 
       it "should return error if no email is provided" do
-        lambda { @client.get_lead_by_email(nil) }.should raise_exception(Exception, "Email must be provided")
+        lambda { @interface.get_lead_by_email(nil) }.should raise_exception(Exception, "Email must be provided")
       end
 
       it "should return SOAP fault if email is invalid" do
-        lambda { @client.get_lead_by_email("JUNK") }.should raise_exception(Savon::SOAP::Fault)
+        lambda { @interface.get_lead_by_email("JUNK") }.should raise_exception(Savon::SOAP::Fault)
       end
 
       it "should return error if no email is provided on sync lead" do
-        lambda { @client.sync_lead(nil, "", {}) }.should raise_exception(Exception, "Email must be provided")
+        lambda { @interface.sync_lead(nil, "", {}) }.should raise_exception(Exception, "Email must be provided")
       end
 
       after do
@@ -52,14 +52,14 @@ describe Marketo do
 
       it "should get lead by id" do
         lead_record = Marketo::Lead.new(nil, IDNUM)
-        retVal = @client.get_lead_by_id(IDNUM)
+        retVal = @interface.get_lead_by_id(IDNUM)
         retVal.should be_a_kind_of(Marketo::Lead)
         retVal.idnum.should == IDNUM
       end
 
       it "should get lead by email" do
         lead_record = Marketo::Lead.new(EMAIL)
-        retVal = @client.get_lead_by_email(EMAIL)
+        retVal = @interface.get_lead_by_email(EMAIL)
         retVal.should be_a_kind_of(Marketo::Lead)
         retVal.email.should == EMAIL
       end
@@ -75,7 +75,7 @@ describe Marketo do
       end
 
       it "should sync lead with Marketo" do
-        retVal = @client.sync_lead(USER[:email], COOKIE, { "FirstName"=>USER[:first_name],
+        retVal = @interface.sync_lead(USER[:email], COOKIE, { "FirstName"=>USER[:first_name],
                                                            "LastName"=>USER[:last_name],
                                                            "Company"=>"Backupify" })
         retVal.should be_a_kind_of(Marketo::Lead)
@@ -92,7 +92,7 @@ describe Marketo do
       end
 
       it "should add lead to marketo list" do
-        @client.add_lead_to_list(IDNUM, "Inbound Signups").should == true
+        @interface.add_lead_to_list(IDNUM, "Inbound Signups").should == true
       end
 
       after do
@@ -115,14 +115,14 @@ describe Marketo do
           {:lead_id=>"1000085", :status=>"UPDATED", :error=>nil}
         ]
 
-        response = @client.sync_multiple multi_users
+        response = @interface.sync_multiple multi_users
 
         response.should == test_values
       end
 
       it "should raise exception if empty array is passed" do
         err_text = "Empty leads hash, nothing to sync"
-        lambda { @client.sync_multiple(nil) }.should raise_exception(Exception, err_text)
+        lambda { @interface.sync_multiple(nil) }.should raise_exception(Exception, err_text)
       end
 
       after do


### PR DESCRIPTION
Raise Marketo client timeouts to eliminate sporadic errors:
`<HTTPClient::ConnectTimeoutError: execution expired>` and `HTTPClient::ReceiveTimeoutError: execution expired>`

Jira issue https://jira.backupify.com/browse/BETA-525

Should be merged after: 
https://github.com/backupify/httpi/pull/1/files
